### PR TITLE
adding the option of passing showdown options to the showdown coverter

### DIFF
--- a/src/rollup-plugin-markdown.js
+++ b/src/rollup-plugin-markdown.js
@@ -3,14 +3,21 @@ const path = require('path')
 const matter = require('gray-matter')
 const showdown = require('showdown')
 
-const converter = new showdown.Converter({
-  metadata: true,
-})
-
-converter.setFlavor('github')
+showdown.setFlavor('github')
 
 const markdownPlugin = (options = {}) => {
-  const filter = createFilter(options.include, options.exclude)
+  const {
+    include,
+    exclude,
+    showdown: showdownOpts = {}
+  } = options
+
+  const converter = new showdown.Converter({
+    metadata: true,
+    ...showdownOpts
+  })
+
+  const filter = createFilter(include, exclude)
 
   return {
     name: 'rollup-plugin-markdown',


### PR DESCRIPTION
Hey there - not sure if you are accepting pull requests, but here goes.

This change allows users to pass options down into showdown's converter, so I can add custom syntax highlighting (using highlight.js, see https://github.com/unional/showdown-highlightjs-extension ) to my svelte-based blog.

FYI I was contemplating simply being able to pass in a different showdown.Converter alltogether, but I ended up doing this instead, since it seems simpler.